### PR TITLE
Fix Split tool tempdir cleanup

### DIFF
--- a/BaseTools/Source/Python/Split/Split.py
+++ b/BaseTools/Source/Python/Split/Split.py
@@ -159,6 +159,7 @@ def splitFile(inputfile, position, outputdir=None, outputfile1=None, outputfile2
             with open(outputfile2, "wb") as fout:
                 fout.write(b'')
         else:
+            tempdir = None
             try:
                 tempdir = tempfile.mkdtemp()
                 tempfile1 = os.path.join(tempdir, "file1.bin")
@@ -177,7 +178,7 @@ def splitFile(inputfile, position, outputdir=None, outputfile1=None, outputfile2
                 logger.error("Split file failed")
                 raise(e)
             finally:
-                if os.path.exists(tempdir):
+                if tempdir and os.path.exists(tempdir):
                     shutil.rmtree(tempdir)
 
 


### PR DESCRIPTION
## Summary
- initialize `tempdir` before the `try` block in `SplitFile`
- guard cleanup with a check for `tempdir`

## Testing
- `pytest BaseTools/Source/Python/tests/Split/test_split.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686ceb639690832ca99dd709f105c32e